### PR TITLE
[#7] MySQL, Redis 클러스터에 생성

### DIFF
--- a/kubernetis/redis-deployment.yaml
+++ b/kubernetis/redis-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7.4-alpine
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        command:
+        - "redis-server"
+        - "--apependonly"
+        - "yes"
+      volumes:
+      - name: redis-data
+        persistentVolumeClaim:
+          claimName: redis-pvc

--- a/kubernetis/redis-pvc.yaml
+++ b/kubernetis/redis-pvc.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 8Gi

--- a/kubernetis/redis-pvc.yaml
+++ b/kubernetis/redis-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetis/redis-service.yaml
+++ b/kubernetis/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: default
+spec:
+  selector:
+    app: redis
+  ports:
+  - protocol: TCP
+    port: 6379
+    targetPort: 6379
+  type: ClusterIP

--- a/kubernetis/serverDB-deployment.yaml
+++ b/kubernetis/serverDB-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: serverdb-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: serverdb
+  template:
+    metadata:
+      labels:
+        app: serverdb
+    spec:
+      containers:
+      - name: serverdb
+        image: mysql:8.4
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: rootpassword
+        - name: MYSQL_DATABASE
+          value: qlabdb
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: serverdb-data
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: serverdb-data
+        persistentVolumeClaim:
+          claimName: serverdb-pvc

--- a/kubernetis/serverDB-pvc.yaml
+++ b/kubernetis/serverDB-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: serverdb-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetis/serverDB-service.yaml
+++ b/kubernetis/serverDB-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: serverdb-service
+  namespace: default
+spec:
+  selector:
+    app: serverdb
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 3306
+    targetPort: 3306


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
서비스에서 활용할 MySQL 서버와 Redis 를 쿠버네티스로 올리기 위해서 yaml 파일을 작성하였습니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
serverDB 올리기 위한 yaml 파일 작성.
redis 를 올리기 위한 yaml 파일 작성.

```bash
# 실행 명령어
kubectl apply -f kubernetis/
```


## ✅ 작업 체크리스트
- [x] serverDB deployment, service, PVC
- [x] Redis deployment, service, PVC

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
